### PR TITLE
Improved player death

### DIFF
--- a/Assets/Characters/Enemies/Caster/Ghost/Prefabs/Ghost.prefab
+++ b/Assets/Characters/Enemies/Caster/Ghost/Prefabs/Ghost.prefab
@@ -207,4 +207,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 4
+  canMove: 1
   collisionOffset: 0.5

--- a/Assets/Characters/Enemies/Melee/BaseMeleeEnemy.prefab
+++ b/Assets/Characters/Enemies/Melee/BaseMeleeEnemy.prefab
@@ -191,4 +191,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 4
+  canMove: 1
   collisionOffset: 0.5

--- a/Assets/Characters/Enemies/WarCaster/Bringer Of Death/Prefabs/Bringer Of Death.prefab
+++ b/Assets/Characters/Enemies/WarCaster/Bringer Of Death/Prefabs/Bringer Of Death.prefab
@@ -210,4 +210,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 4
+  canMove: 1
   collisionOffset: 0.5

--- a/Assets/Scripts/Characters/Enemies/BaseEnemy.cs
+++ b/Assets/Scripts/Characters/Enemies/BaseEnemy.cs
@@ -51,8 +51,7 @@ namespace Assets.Scripts.Characters.Enemies
             var layer = Mathf.CeilToInt(relativePos.y * 2);
             spriteRenderer.sortingOrder = relativePos.y < 0f ? layer : layer + 1;
 
-            if (!playerStats.godMode)
-                TryAttack();
+            TryAttack();
         }
 
         public virtual void TryAttack()

--- a/Assets/Scripts/Characters/Player/PlayerController.cs
+++ b/Assets/Scripts/Characters/Player/PlayerController.cs
@@ -8,6 +8,9 @@ namespace Assets.Scripts.Characters.Player
     public class PlayerController : MonoBehaviour
     {
         [SerializeField]
+        public bool canAttack = true;
+
+        [SerializeField]
         public GameObject AoeAttack, SwordSwingAttack;
 
         [SerializeField]
@@ -40,7 +43,7 @@ namespace Assets.Scripts.Characters.Player
         // Function gets executed by Player Input
         void OnMainAttack()
         {
-            if (SwordSwingAttack != null)
+            if (SwordSwingAttack != null && canAttack)
             {
                 SwordSwingAttack.SetActive(true);
             }
@@ -49,7 +52,7 @@ namespace Assets.Scripts.Characters.Player
         // Function gets executed by Player Input
         void OnSecondaryAttack()
         {
-            if (activeAoeAttack == null)
+            if (activeAoeAttack == null && canAttack)
             {
                 animator.Play("Cast");
                 activeAoeAttack = Object.Instantiate(AoeAttack, transform.position, Quaternion.identity);

--- a/Assets/Scripts/Characters/Player/PlayerStats.cs
+++ b/Assets/Scripts/Characters/Player/PlayerStats.cs
@@ -8,10 +8,12 @@ namespace Assets.Scripts.Characters.Player
 {
     [RequireComponent(typeof(Animator))]
     [RequireComponent(typeof(SpriteRenderer))]
+    [RequireComponent(typeof(PlayerMovement))]
+    [RequireComponent(typeof(PlayerController))]
     public class PlayerStats : MonoBehaviour
     {
         [SerializeField]
-        public bool godMode;
+        public bool invincible = false;
 
         [SerializeField]
         private HealthGlobe HealthGlobe;
@@ -21,12 +23,16 @@ namespace Assets.Scripts.Characters.Player
 
         private Animator animator;
         private SpriteRenderer spriteRenderer;
+        private PlayerMovement playerMovement;
+        private PlayerController playerController;
         private int currentHP;
 
         void Awake()
         {
             spriteRenderer = GetComponent<SpriteRenderer>();
             animator = GetComponent<Animator>();
+            playerMovement = GetComponent<PlayerMovement>();
+            playerController = GetComponent<PlayerController>();
             currentHP = healthPoints;
         }
 
@@ -34,6 +40,9 @@ namespace Assets.Scripts.Characters.Player
         {
             animator.Play("Idle");
             currentHP = healthPoints;
+            invincible = false;
+            playerMovement.canMove = true;
+            playerController.canAttack = true;
             HealthGlobe.UpdateHealthGlobe((float)currentHP / healthPoints);
         }
 
@@ -50,6 +59,9 @@ namespace Assets.Scripts.Characters.Player
 
         public void TakeDamage(int damage)
         {
+            if (invincible)
+                return;
+
             var isCrit = RandomHelper.GetRandom(50);
             if (isCrit)
                 damage *= 2;
@@ -75,7 +87,9 @@ namespace Assets.Scripts.Characters.Player
             yield return new WaitForSeconds(delay);
             FindAnyObjectByType<Canvas>().GetComponentInChildren<DeathPopup>(true).gameObject.SetActive(true);
             SoundManager.instance.musicSource.Stop();
-            godMode = true;
+            invincible = true;
+            playerMovement.canMove = false;
+            playerController.canAttack = false;
             spriteRenderer.enabled = false;
         }
     }

--- a/Assets/Scripts/Dungeon/Rooms/RoomManager.cs
+++ b/Assets/Scripts/Dungeon/Rooms/RoomManager.cs
@@ -24,7 +24,7 @@ namespace Assets.Scripts.Dungeon.Rooms
 
         private List<Room> rooms;
 
-        private readonly int roomHeight = 18, roomWidth = 18;
+        private readonly int roomHeight = 18, roomWidth = 22;
         public readonly int corridorLength = 4;
 
         public void GenerateRooms(int minRoomCount, int maxRoomCount)

--- a/Assets/Scripts/Shared/Movement.cs
+++ b/Assets/Scripts/Shared/Movement.cs
@@ -11,6 +11,9 @@ namespace Assets.Scripts.Shared
         protected float moveSpeed = 4f;
 
         [SerializeField]
+        public bool canMove = true;
+
+        [SerializeField]
         private float collisionOffset = 0.5f;
 
         private List<RaycastHit2D> collisions = new List<RaycastHit2D>();
@@ -30,7 +33,7 @@ namespace Assets.Scripts.Shared
 
         public bool Move(Vector2 direction)
         {
-            if (stop)
+            if (stop || !canMove)
                 return false;
 
             // Lets try moving
@@ -55,7 +58,7 @@ namespace Assets.Scripts.Shared
 
         public bool SimpleMove(Vector2 direction)
         {
-            if (stop)
+            if (stop || !canMove)
                 return false;
 
             // Lets try moving


### PR DESCRIPTION
# New
- Enemies and player character now have a `canMove` setting
- On death you can no longer attack or move

# Changed
- `godMode` has been renamed to `invincible` and no enemies still attack when invincible is active, but deal no damage
- Generated rooms now are `22` width instead of `18`